### PR TITLE
fix problem with __m128i undefined on ARM

### DIFF
--- a/src/HexDialogs.cpp
+++ b/src/HexDialogs.cpp
@@ -1311,17 +1311,22 @@ void FindDialog::OnFindAll( bool internal ) {
 //Returns indice of first found if used with (  options & SEARCH_FINDALL) ret_ptr return vector pointer filled with locations at buffer
 //WARNING! THIS FUNCTION WILL CHANGE BFR and/or SEARCH strings if SEARCH_MATCHCASE not selected as an option!
 inline int FindDialog::SearchAtBuffer( char *bfr, int bfr_size, char* search, int search_size, unsigned options, std::vector<int> *ret_ptr ) {
+#ifdef __SSE2__
 	static const int REG_SZ = sizeof(__m128i);
 
 	char internal_array[REG_SZ];
+#endif
 
 	if( bfr_size < search_size )
 		return -1;
+
+#ifdef __SSE2__
 	if(bfr_size < REG_SZ) {
 		memset(&internal_array[0], 0, sizeof(internal_array));
 		memcpy(&internal_array[0], bfr, bfr_size);
 		bfr = &internal_array[0];
 	}
+#endif
 
 	///SEARCH_FINDALL operation supersedes SEARCH_BACKWARDS and SEARCH_WRAPAROUND
 	if(options & SEARCH_FINDALL)


### PR DESCRIPTION
There is a constant REG_SZ, see file modification, that is used conditionally only when __SSE2__ is defined but the variable REG_SZ is defined unconditionally.

This problem cause the compilation to fail on ARM64 architecture.

I added ifdef guards based on __SSE2__ like for the rest of the code. It compiles on macOS on ARM64 architecture.